### PR TITLE
Fix priority error

### DIFF
--- a/server/ProcessPriorityPolicy.cpp
+++ b/server/ProcessPriorityPolicy.cpp
@@ -37,6 +37,9 @@ static int calculateScore(PidPriorityInfo* pnode, int& levelCnt, ProcessStatus l
     int score = 1000;
 
     if (location == FOREGROUND_PROCESS) {
+        if (pnode->priorityLevel == ProcessPriority::PERSISTENT) {
+            return OS_PERSISTENT_PROC_ADJ;
+        }
         score = pnode->oomScore > OS_FOREGROUND_APP_ADJ ? OS_FOREGROUND_APP_ADJ : pnode->oomScore;
         return score;
     } else if (location == SYSTEM_HOME_PROCESS) {


### PR DESCRIPTION

## Summary

*According to the document, there is a lack of persistent priority judgment when the application starts, so the code logic is supplemented.*

## Impact

*Enables users to get the correct application priority.*

## Testing

*OS: Ubuntu 22.04.5 LTS
CPU: 12th Gen Intel® Core™ i7-12700 × 20
Compiler: G++13.1.0
Configuring NuttX and compile:
$ ./build.sh vendor/qemu/boards/smartspeaker/configs/smartspeaker -e -Werror -j8
Running with qemu
$ ./emulator.sh smartspeaker*

