### PR TITLE
fix voiceapp move to background fail

### DIFF
--- a/server/ActivityManagerService.cpp
+++ b/server/ActivityManagerService.cpp
@@ -228,10 +228,9 @@ int ActivityManagerInner::startActivity(const sp<IBinder>& caller, const Intent&
     }
 
     auto taskmanager = getTaskManager(packageInfo.isSystemUI);
-    ActivityStackHandler apptask;
+    ActivityStackHandler apptask = taskmanager->findTask(packageInfo.packageName);
     /** check activity name */
     if (activityName.empty()) {
-        apptask = taskmanager->findTask(packageInfo.packageName);
         if (!apptask) {
             activityName = packageInfo.entry;
         }
@@ -331,6 +330,17 @@ int ActivityManagerInner::startActivityReal(ITaskManager* taskmanager, const str
                 std::make_shared<ActivityRecord>(activityUniqueName, caller, requestCode,
                                                  launchMode, targetTask, intent, mWindowManager,
                                                  taskmanager, &mPendTask);
+        if (intent.mAction == Intent::ACTION_BOOT_GUIDE) {
+            newActivity->setCallback([this]() { startHomeActivity(); });
+        }
+        bool is_home_task =
+                std::any_of(packageInfo.activitiesInfo.begin(), packageInfo.activitiesInfo.end(),
+                            [](const auto& activity) {
+                                return std::any_of(activity.actions.begin(), activity.actions.end(),
+                                                   [](const auto& action) {
+                                                       return action == Intent::ACTION_HOME;
+                                                   });
+                            });
         const auto appInfo = mAppInfo.findAppInfoWithAlive(packageInfo.packageName);
         if (appInfo) {
             newActivity->setAppThread(appInfo);
@@ -344,8 +354,8 @@ int ActivityManagerInner::startActivityReal(ITaskManager* taskmanager, const str
             }
 
             const ProcessPriority priority = (ProcessPriority)packageInfo.priority;
-            const auto task = [this, taskmanager, targetTask, newActivity, startFlag,
-                               priority](const AppAttachTask::Event* e) {
+            const auto task = [this, taskmanager, targetTask, newActivity, startFlag, priority,
+                               is_home_task](const AppAttachTask::Event* e) {
                 mPriorityPolicy.add(e->mPid, true, priority);
                 newActivity->setAppThread(e->mAppRecord);
                 taskmanager->pushNewActivity(targetTask, newActivity, startFlag);
@@ -551,6 +561,7 @@ void ActivityManagerInner::reportActivityStatus(const sp<IBinder>& token, int32_
         }
         case ActivityRecord::DESTROYED: {
             activity->setStatus(ActivityRecord::DESTROYED);
+            activity->executeCallback();
             if (const auto appRecord = activity->getAppRecord()) {
                 bool isSystemUI = appRecord->mIsSystemUI;
                 if (!isSystemUI) {

--- a/server/ActivityRecord.h
+++ b/server/ActivityRecord.h
@@ -97,6 +97,13 @@ public:
 
     friend std::ostream& operator<<(std::ostream& os, const ActivityRecord& record);
 
+    void setCallback(std::function<void()> launcher) {
+        mLauncher = launcher;
+    }
+    void executeCallback() {
+        if (mLauncher) mLauncher();
+    }
+
 private:
     void create();
     void start();
@@ -122,6 +129,8 @@ private:
     sp<::os::wm::IWindowManager> mWindowService;
     ITaskManager* mTaskManager;
     TaskBoard* mPendTask;
+
+    std::function<void()> mLauncher;
 };
 
 using ActivityHandler = std::shared_ptr<ActivityRecord>;

--- a/server/TaskManager.h
+++ b/server/TaskManager.h
@@ -63,6 +63,7 @@ public:
     virtual std::ostream& print(std::ostream& os) {
         return os;
     }
+    virtual void setHomeTask(const ActivityStackHandler& task) {}
 };
 
 class TaskManagerFactory {

--- a/server/TaskStackManager.cpp
+++ b/server/TaskStackManager.cpp
@@ -65,8 +65,23 @@ bool TaskStackManager::moveTaskToBackground(const ActivityStackHandler& targetSt
         return false;
     }
 
+    // If it's above HomeTask, move it below HomeTask, otherwise no need to move it
+    auto hometask_index = std::find(mAllTasks.begin(), mAllTasks.end(), mHomeTask);
+    if (hometask_index == mAllTasks.end()) {
+        mAllTasks.remove(targetStack);
+        mAllTasks.push_back(targetStack);
+    } else {
+        for (auto iter = mAllTasks.begin(); iter != hometask_index; ++iter) {
+            if (*iter == targetStack) {
+                mAllTasks.erase(iter);
+                mAllTasks.insert(++hometask_index, targetStack);
+                break;
+            }
+        }
+    }
+
     if (targetStack == activeTask) {
-        isBeforeHomeTask = true;
+        // isBeforeHomeTask = true;
         auto topActivity = targetStack->getTopActivity();
         topActivity->lifecycleTransition(ActivityRecord::PAUSED);
         targetStack->setForeground(false);

--- a/server/TaskStackManager.h
+++ b/server/TaskStackManager.h
@@ -56,6 +56,9 @@ public:
 
     friend std::ostream& operator<<(std::ostream& os, const TaskStackManager& task);
     std::ostream& print(std::ostream& os) override;
+    void setHomeTask(const ActivityStackHandler& task) override {
+        mHomeTask = task;
+    }
 
 private:
     std::list<ActivityStackHandler> mAllTasks;


### PR DESCRIPTION

## Summary

*wake up the speaker after factory reset; this is because the app will become a hometask and cannot be moved to the background. In addition, even if it is moved to the background, it will be started multiple times. This commit changes the assignment logic of hometask and the background application movement logic to fix this problem*

## Impact

*1. The wake-up animation can be started normally
2. Hometask can be assigned correctly
3. The same application will not be started multiple times
4. Optimized some implementations and the logic is clearer*

## Testing

*1. Build and burn the image to the real machine
2. Wake up app after connecting to the Internet successfully and ensure that app can exit normally
3. Click to turn on smart life and continue to wake up, app can appear in the foreground and exit normally*

