### PR TITLE
After burning the AP under image_test, automation cannot be executed

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -62,4 +62,13 @@ config ACTIVITY_SERVICE_LOG_WITH_COLOR
 	help
 		Enable log with color
 
+config AMS_REQUEST_TIMEOUT_MS
+	int "Request timeout in milliseconds"
+	default 10000 if !MM_KASAN
+	default 30000 if MM_KASAN
+	help
+		This option defines the request timeout in milliseconds.
+		The default is 10000 ms (10 seconds) when KASAN is not enabled,
+		and 30000 ms (30 seconds) when KASAN is enabled.
+
 endif

--- a/app/ApplicationThread.cpp
+++ b/app/ApplicationThread.cpp
@@ -32,6 +32,7 @@
 #include "ServiceClientRecord.h"
 #include "app/Application.h"
 #include "app/ContextImpl.h"
+#include "app/Logger.h"
 #include "os/app/BnApplicationThread.h"
 #include "os/app/IApplicationThread.h"
 


### PR DESCRIPTION
Enable logging on the client side to confirm that the client can receive the information.

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

*The ThreadApplication.cpp file does not contain the logger.h header file, which results in invalid log output in the cpp file and reduces the debugging efficiency.*

## Impact

*The log will be more complete.*

## Testing



