### PR TITLE
Solve the problem of being unable to enter the control center

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -62,4 +62,13 @@ config ACTIVITY_SERVICE_LOG_WITH_COLOR
 	help
 		Enable log with color
 
+config AMS_REQUEST_TIMEOUT_MS
+	int "Request timeout in milliseconds"
+	default 10000 if !CONFIG_MM_KASAN
+	default 30000 if CONFIG_MM_KASAN
+	help
+		This option defines the request timeout in milliseconds.
+		The default is 10000 ms (10 seconds) when KASAN is not enabled,
+		and 30000 ms (30 seconds) when KASAN is enabled.
+
 endif

--- a/server/TaskBoard.h
+++ b/server/TaskBoard.h
@@ -115,11 +115,7 @@ enum TASK_LABEL {
     SERVICE_STATUS_END = 230,
 };
 
-#ifdef CONFIG_MM_KASAN
-#define REQUEST_TIMEOUT_MS 30000 // 30 seconds
-#else
-#define REQUEST_TIMEOUT_MS 10000 // 10 seconds
-#endif
+constexpr int REQUEST_TIMEOUT_MS = CONFIG_AMS_REQUEST_TIMEOUT_MS;
 /***************************************************************************/
 
 } // namespace am


### PR DESCRIPTION
## Summary

AMS sets a timeout, which is 10s in the KASAN version. If the control center has not finished starting within this time, we can successfully pull down the control center by increasing the timeout. And moved the time options to Kconfig.

## Impact

Increased timeout

