### PR TITLE
Clicking the standard window or single window does not lead to the re…

### DIFF
--- a/server/ActivityManagerService.cpp
+++ b/server/ActivityManagerService.cpp
@@ -228,9 +228,10 @@ int ActivityManagerInner::startActivity(const sp<IBinder>& caller, const Intent&
     }
 
     auto taskmanager = getTaskManager(packageInfo.isSystemUI);
-    ActivityStackHandler apptask = taskmanager->findTask(packageInfo.packageName);
+    ActivityStackHandler apptask;
     /** check activity name */
     if (activityName.empty()) {
+        apptask = taskmanager->findTask(packageInfo.packageName);
         if (!apptask) {
             activityName = packageInfo.entry;
         }


### PR DESCRIPTION
## Summary

The initialization location of the application task has been changed, resulting in only one task and one activity. Now restore the code.

## Impact

Click Standard Window or Single Window to jump to the response interface normally.

