### PR TITLE
Solve the problem of being unable to enter the control center

### DIFF
--- a/server/TaskBoard.h
+++ b/server/TaskBoard.h
@@ -115,11 +115,7 @@ enum TASK_LABEL {
     SERVICE_STATUS_END = 230,
 };
 
-#ifdef CONFIG_MM_KASAN
-#define REQUEST_TIMEOUT_MS 30000 // 30 seconds
-#else
-#define REQUEST_TIMEOUT_MS 10000 // 10 seconds
-#endif
+constexpr int REQUEST_TIMEOUT_MS = CONFIG_AMS_REQUEST_TIMEOUT_MS;
 /***************************************************************************/
 
 } // namespace am


### PR DESCRIPTION
## Summary

AMS sets a timeout, which is 10s in the KASAN version. If the control center has not finished starting within this time, we can successfully pull down the control center by increasing the timeout. And moved the time options to Kconfig.

## Impact

Increased timeout
